### PR TITLE
try to import simplejson first

### DIFF
--- a/vimeo/auth.py
+++ b/vimeo/auth.py
@@ -19,7 +19,12 @@ under the license.
 
 import urllib
 import base64
-import json
+
+try: 
+    import simplejson as json
+except ImportError: 
+    import json
+
 from copy import copy
 
 from tornado.httpclient import HTTPClient

--- a/vimeo/uploads.py
+++ b/vimeo/uploads.py
@@ -17,7 +17,12 @@ specific language governing permissions and limitations
 under the license.
 """
 import logging as log
-import json
+
+try: 
+    import simplejson as json
+except ImportError: 
+    import json
+
 from urllib import urlencode
 
 from tornado.httpclient import HTTPClient, HTTPError

--- a/vimeo/vimeoresource.py
+++ b/vimeo/vimeoresource.py
@@ -16,7 +16,11 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 """
-import json
+try: 
+    import simplejson as json
+except ImportError: 
+    import json
+
 import os
 from urllib import urlencode
 import logging as log


### PR DESCRIPTION
Since `json` was added in 2.6, `simplejson` has the advantage of working on more Python versions (2.4+).

`simplejson` is also updated more frequently than Python, so if you want the latest version, it's best to use `simplejson` if possible

Try to use `simplejson` and then use `json` as a fallback.
