### PR TITLE
fixed header bug and adds pictures resource

### DIFF
--- a/vimeo/resources.py
+++ b/vimeo/resources.py
@@ -212,6 +212,8 @@ class Video(SingularResource):
                              'multi_put': True},
                 'stats'   : {'methods': ["GET"],
                              'accept': 'stats'},
+                'pictures': {'methods': ["GET", "POST", "PATCH"],
+                             'accept': 'picture'},
         })
 
 mapper = {

--- a/vimeo/vimeoresource.py
+++ b/vimeo/vimeoresource.py
@@ -224,7 +224,7 @@ class VimeoResource(object):
         elif hasattr(self, 'accept'):
             accept = self.accept
 
-        headers = {"Accept": 'application/vnd.vimeo.%s+json; v3.0' % accept,
+        headers = {"Accept": config['accept'],
                    "User-Agent": config['user-agent']}
 
         # HTTPClient doesn't like when requests with these methods have bodies


### PR DESCRIPTION
`pictures` resources can now be requested and bug was fixed with the `accept` header
