### PR TITLE
create universal wheel, update package version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[bdist_wheel]
+# This flag says that the code is written to work on both Python 2 and Python 3. 
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
     from distutils.core import setup
 
 setup(name='PyVimeo',
-    version='0.2.1',
+    version='0.3.1',
     description='Simple interaction with the Vimeo API.',
     url='https://developer.vimeo.com/',
     author='Vimeo',

--- a/vimeo/__init__.py
+++ b/vimeo/__init__.py
@@ -3,6 +3,6 @@
 
 from __future__ import absolute_import
 
-version = (0, 1, 1)
+version = (0, 3, 1)
 
 from .client import VimeoClient


### PR DESCRIPTION
- Update `version` to latest in PyPi 

- Switch to using a universal wheel since our code works on both Python 2 and Python 3. This is good practice and avoids arbitrary code execution for installation. (avoids setup.py)

*This should also include a new PyPi release* 