### PR TITLE
fix for requests >= 2.11.0

### DIFF
--- a/vimeo/upload.py
+++ b/vimeo/upload.py
@@ -105,7 +105,7 @@ class UploadVideoMixin(object):
             upload_target,
             timeout=None,
             headers={
-                'Content-Length': size,
+                'Content-Length': str(size),
                 'Content-Range': 'bytes: %d-%d/%d' % (last_byte, size, size)
             }, data=f)
 


### PR DESCRIPTION
Change Content-Length from int to string to work with requests >= 2.11.0
Fix issue #88 