### PR TITLE
Fixes typo in exception name.

### DIFF
--- a/vimeo/client.py
+++ b/vimeo/client.py
@@ -9,7 +9,7 @@ import requests
 from .auth.client_credentials import ClientCredentialsMixin
 from .auth.authorization_code import AuthorizationCodeMixin
 from .upload import UploadMixin
-from .exceptions import APIRateLimitExededFailure
+from .exceptions import APIRateLimitExceededFailure
 
 
 class VimeoClient(ClientCredentialsMixin, AuthorizationCodeMixin, UploadMixin):
@@ -75,7 +75,7 @@ class VimeoClient(ClientCredentialsMixin, AuthorizationCodeMixin, UploadMixin):
 
             response = request_func(url, **kwargs)
             if response.status_code == 429:
-                raise APIRateLimitExededFailure(
+                raise APIRateLimitExceededFailure(
                     response, 'Too many API requests'
                 )
             return response

--- a/vimeo/exceptions.py
+++ b/vimeo/exceptions.py
@@ -83,7 +83,7 @@ class APIRateLimitExceededFailure(BaseVimeoException):
 
     def _get_message(self, response):
         guidelines = 'https://developer.vimeo.com/guidelines/rate-limiting'
-        message = super(APIRateLimitExededFailure, self)._get_message(
+        message = super(APIRateLimitExceededFailure, self)._get_message(
             response
         )
         limit_reset_time = response.headers.get('x-ratelimit-reset')


### PR DESCRIPTION
Looks like a typo was fixed partially, leading to load failures.