### PR TITLE
spelling error and handling non-standard response from vimeo

### DIFF
--- a/vimeo/exceptions.py
+++ b/vimeo/exceptions.py
@@ -10,7 +10,7 @@ class BaseVimeoException(Exception):
             pass
 
         if json:
-            message = json['error']
+            message = json.get('error') or json.get('Description')
         else:
             message = response.text
         return message

--- a/vimeo/upload.py
+++ b/vimeo/upload.py
@@ -143,7 +143,7 @@ class UploadPictureMixin(object):
         with io.open(filename, 'rb') as f:
             upload_resp = self.put(picture['link'], data=f)
         if upload_resp.status_code != 200:
-            raise PictureUploadFailure(texttrack, "Failed uploading picture")
+            raise PictureUploadFailure(upload_resp, "Failed uploading picture")
 
         if activate:
             active = self.patch(picture['uri'], data={"active": "true"})


### PR DESCRIPTION
vimeo/upload.py: a simple copy/paste error.. texttrack isn't defined here, but upload_resp is.

vimeo/exceptions.py: in the case where a corrupt jpg file is uploaded to Vimeo OR if the signature used for thumbnail uploads has expired, a non-standard response will be returned. This response does not contain an 'error' element and will cause the call to fail. The non-standard response will contain a 'Description', though.