### PR TITLE
Add JSON filter to upload, replace, upload_picture and upload_texttrack methods.

### DIFF
--- a/vimeo/client.py
+++ b/vimeo/client.py
@@ -16,7 +16,7 @@ class VimeoClient(ClientCredentialsMixin, AuthorizationCodeMixin, UploadMixin):
     """Client handle for the Vimeo API."""
 
     API_ROOT = "https://api.vimeo.com"
-    HTTP_METHODS = {'head', 'get', 'post', 'put', 'patch', 'options', 'delete'}
+    HTTP_METHODS = set(('head', 'get', 'post', 'put', 'patch', 'options', 'delete'))
     ACCEPT_HEADER = "application/vnd.vimeo.*;version=3.2"
     USER_AGENT = "pyvimeo 0.1; (http://developer.vimeo.com/api/docs)"
 


### PR DESCRIPTION
These changes will help avoid hitting the rate limit. It's possible to specified other fields wanted in `upload_picture` and `upload_textrack` methods with the `fields` argument.

I also made a small change that make vimeo.py compatible with python 2.6 (unfortunately I currently need this, but soon that will be move to 2.7 and 3.6 :-( ).