### PR TITLE
Make tusclient uploader configurable

### DIFF
--- a/vimeo/exceptions.py
+++ b/vimeo/exceptions.py
@@ -16,8 +16,13 @@ class BaseVimeoException(Exception):
 
         if json:
             message = json.get('error') or json.get('Description')
-        else:
+        elif hasattr(response, 'text'):
             message = response.text
+        elif hasattr(response, 'message'):
+            # this condition e.g. applies when propagating a Tusclient exception
+            message = response.message
+        else:
+            message = u'Unknown error: ' + repr(response)
 
         return message
 


### PR DESCRIPTION
This PR adds the optional `tus_uploader_config` parameter to the `upload()` and `replace()` methods.
Also, `BaseVimeoException` is slightly changed in order to be able to propagate tusclient error messages.