### PR TITLE
Default copy for Exception responses lacking necessary fields.

### DIFF
--- a/vimeo/exceptions.py
+++ b/vimeo/exceptions.py
@@ -17,7 +17,8 @@ class BaseVimeoException(Exception):
         if json:
             message = json.get('error') or json.get('Description')
         else:
-            message = response.text
+            response_message = getattr(response, 'message', 'There was an unexpected error.')
+            message = getattr(response, 'text', response_message)
 
         return message
 


### PR DESCRIPTION
What:
* Adds fallback logic when probing an `BaseVimeoException`'s `__get_message` method.

Why:
* Various S/O tickets reference  an `AttributeError` related to failed "lengthy" TUS uploads.
* TUS upload exception responses trigger the `else` case above. The format of the response is not guaranteed. So we attempt to fetch a message or provide default copy.

@erunion 