### PR TITLE
Specify tuspy version explicitly.

### DIFF
--- a/example/upload.py
+++ b/example/upload.py
@@ -21,7 +21,7 @@ client = vimeo.VimeoClient(
 # Create a variable with a hard coded path to your file system
 file_name = '<full path to a video on the filesystem>'
 
-print 'Uploading: %s' % file_name
+print('Uploading: %s' % file_name)
 
 try:
     # Upload the file and include the video title and description.
@@ -33,7 +33,7 @@ try:
 
     # Get the metadata response from the upload and log out the Vimeo.com url
     video_data = client.get(uri + '?fields=link').json()
-    print '"%s" has been uploaded to %s' % (file_name, video_data['link'])
+    print('"%s" has been uploaded to %s' % (file_name, video_data['link']))
 
     # Make an API call to edit the title and description of the video.
     client.patch(uri, data={
@@ -42,16 +42,16 @@ try:
                        "Python SDK."
     })
 
-    print 'The title and description for %s has been edited.' % uri
+    print('The title and description for %s has been edited.' % uri)
 
     # Make an API call to see if the video is finished transcoding.
     video_data = client.get(uri + '?fields=transcode.status').json()
-    print 'The transcode status for %s is: %s' % (
+    print('The transcode status for %s is: %s' % (
         uri,
         video_data['transcode']['status']
-    )
+    ))
 except vimeo.exceptions.VideoUploadFailure as e:
     # We may have had an error. We can't resolve it here necessarily, so
     # report it to the user.
-    print 'Error uploading %s' % file_name
-    print 'Server reported: %s' % e.message
+    print('Error uploading %s' % file_name)
+    print('Server reported: %s' % e.message)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='PyVimeo',
     author_email='support@vimeo.com',
     license='Apache License, Version 2.0, January 2004',
     packages=['vimeo', 'vimeo/auth'],
-    install_requires=['requests>=2.4.0', 'tuspy>=0.2.1'],
+    install_requires=['requests>=2.4.0', 'tuspy==0.2.1'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
What:
* Makes `upload` example Python 3 friendly.
* Changes `tuspy` back to `0.2.1` as an exact match.

Why:
* Internal `tuspy` library changes will not function with Python 2.7 out of the box, without modifications.

Tidbits:

* The [line](https://github.com/tus/tus-py-client/blob/v0.2.3/tusclient/request.py#L60) in question which was blowing up for `tuspy`  versions `>=0.2.2`.
* The [line](https://github.com/tus/tus-py-client/blob/v0.2.1/tusclient/request.py#L70) which serves the same function in `tuspy` version `0.2.1`.

The difference between them, is the `TusRequest.handle` attribute. For `0.2.1` it is a `pycurl` instance, which appears to be able to handle unicode characters in a Python `2.7` string.
While the `TusRequest.handle` attribute for versions `>=0.2.2`  is an `http.client.HTTPSConnection` instance which appears to not function for Python `2.X`, even if at the IO boundary we specify the file encoding as `utf-8`.

The screenshot below, demonstrates an upload (which was failing in the same manor as various user reports) is now succeeding. 

![screen shot 2018-09-06 at 4 35 44 pm](https://user-images.githubusercontent.com/9296941/45232887-0ea46880-b29f-11e8-8705-0238c6c7c64f.png)

TL;DR This should fix the various user reports that have been received.

@erunion 