### PR TITLE
Support any new version of tus-py-client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='PyVimeo',
     author_email='support@vimeo.com',
     license='Apache License, Version 2.0, January 2004',
     packages=['vimeo', 'vimeo/auth'],
-    install_requires=['requests>=2.4.0', 'tuspy==0.2.1'],
+    install_requires=['requests>=2.4.0', 'tuspy>=0.2.1'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
Hey!

I have an issue when I tried to install `vimeo.py` via `pipenv`:

```
Warning: Your dependencies could not be resolved. You likely have a mismatch in your sub-dependencies.
  You can use $ pipenv install --skip-lock to bypass this mechanism, then run $ pipenv graph to inspect the situation.
  Hint: try $ pipenv lock --pre if it is a pre-release dependency.
Could not find a version that matches certifi==2017.7.27.1,==2018.8.24,>=2017.4.17 (from -r pipenv-ppekn1cn-constraints.txt (line 44))
Tried: 0.0.1, 0.0.2, 0.0.3, 0.0.4, 0.0.5, 0.0.6, 0.0.7, 0.0.8, 1.0.0, 1.0.1, 1.0.1, 14.5.14, 2015.4.28, 2015.4.28, 2015.9.6, 2015.9.6, 2015.9.6.1, 2015.9.6.1, 2015.9.6.2, 2015.9.6.2, 2015.11.20, 2015.11.20, 2015.11.20.1, 2015.11.20.1, 2016.2.28, 2016.2.28, 2016.8.2, 2016.8.2, 2016.8.8, 2016.8.8, 2016.8.31, 2016.8.31, 2016.9.26, 2016.9.26, 2017.1.23, 2017.1.23, 2017.4.17, 2017.4.17, 2017.7.27, 2017.7.27, 2017.7.27.1, 2017.7.27.1, 2017.11.5, 2017.11.5, 2018.1.18, 2018.1.18, 2018.4.16, 2018.4.16, 2018.8.13, 2018.8.13, 2018.8.24, 2018.8.24
There are incompatible versions in the resolved dependencies.
```

See how `certifi` was added in `tuspy==0.2.1`: https://github.com/tus/tus-py-client/blob/v0.2.1/setup.py#L16 and comparing to how it's loaded in the latest version https://github.com/tus/tus-py-client/blob/master/setup.py#L12
