### PR TITLE
Update tuspy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='PyVimeo',
     author='Vimeo',
     author_email='support@vimeo.com',
     packages=['vimeo', 'vimeo/auth'],
-    install_requires=['requests>=2.4.0', 'tuspy==0.2.1'],
+    install_requires=['requests>=2.4.0', 'tuspy==0.2.4'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',


### PR DESCRIPTION
Version 0.2.2 replaced the use of PyCurl with builtin http.client,
which makes installing this package much easier, since the
curl system dependency isn't needed anymore.

https://github.com/tus/tus-py-client/releases